### PR TITLE
Add report apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "piano-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/interfaces/access.ts
+++ b/src/lib/interfaces/access.ts
@@ -1,31 +1,16 @@
-import { User } from "./user";
+import { Resource } from './resource';
+import { Term } from './term';
+import { User } from './user';
 
 export interface Access {
   access_id: string;
   parent_access_id: string | null;
   granted: boolean;
-  resource: {
-    rid: string;
-    aid: string;
-    deleted: boolean;
-    disabled: boolean;
-    create_date: number;
-    update_date: number;
-    publish_date: number;
-    name: string;
-    description: string;
-    image_url: string | null;
-    type: string;
-    type_label: string;
-    bundle_type: string;
-    bundle_type_label: string;
-    purchase_url: string | null;
-    resource_url: string | null;
-    external_id: string | null;
-    is_fbia_resource: boolean;
-  };
+  revoked: boolean;
+  resource: Resource;
   user: User;
   expire_date: number | null;
   start_date: number;
   can_revoke_access: boolean;
+  term: Term;
 }

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -124,3 +124,14 @@ export interface PublisherUserAccessListParams {
   limit: number;
   cross_app?: boolean;
 }
+
+export interface PublisherSubscriptionListPrarams {
+  type?: string;
+  start_date?: string;
+  end_date?: string;
+  q?: string;
+  offset: number;
+  limit: number;
+  select_by?: string;
+  status?: string;
+}

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -141,3 +141,13 @@ export interface PublisherConversionListPrarams {
   offset: number;
   limit: number;
 }
+
+export interface PublisherExportCreateTransactionsReportV2Params {
+  export_name: string;
+  transactions_type?: 'all' | 'purchases' | 'refunds';
+  order_by?: string;
+  order_direction?: OrderDirection;
+  q?: string;
+  date_from?: string;
+  date_to?: string;
+}

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -135,3 +135,9 @@ export interface PublisherSubscriptionListPrarams {
   select_by?: string;
   status?: string;
 }
+
+export interface PublisherConversionListPrarams {
+  uid?: string;
+  offset: number;
+  limit: number;
+}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -1,5 +1,6 @@
 import { User } from './user';
 import { Access } from './access';
+import { SubscriptionList } from './subscription-list';
 
 export interface ApiResponse {
   code: number;
@@ -38,3 +39,7 @@ export interface PublisherUserAccessListResponse extends ApiResponse {
 export interface PublisherUserAccessActiveCountResponse extends ApiResponse {
   data: number;
 }
+
+export interface PublisherSubscriptionListResponse
+  extends ApiResponse,
+    SubscriptionList {}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -1,6 +1,7 @@
 import { User } from './user';
 import { Access } from './access';
 import { SubscriptionList } from './subscription-list';
+import { ConversionList } from './conversion-list';
 
 export interface ApiResponse {
   code: number;
@@ -43,3 +44,7 @@ export interface PublisherUserAccessActiveCountResponse extends ApiResponse {
 export interface PublisherSubscriptionListResponse
   extends ApiResponse,
     SubscriptionList {}
+
+export interface PublisherConversionListResponse
+  extends ApiResponse,
+    ConversionList {}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -2,6 +2,7 @@ import { User } from './user';
 import { Access } from './access';
 import { SubscriptionList } from './subscription-list';
 import { ConversionList } from './conversion-list';
+import { Export } from './export';
 
 export interface ApiResponse {
   code: number;
@@ -48,3 +49,8 @@ export interface PublisherSubscriptionListResponse
 export interface PublisherConversionListResponse
   extends ApiResponse,
     ConversionList {}
+
+export interface PublisherExportCreateTransactionsReportV2Response
+  extends ApiResponse {
+  export: Export;
+}

--- a/src/lib/interfaces/conversion-list.ts
+++ b/src/lib/interfaces/conversion-list.ts
@@ -1,0 +1,6 @@
+import { Conversion } from './conversion';
+import { List } from './list';
+
+export interface ConversionList extends List {
+  conversions: Conversion[];
+}

--- a/src/lib/interfaces/conversion.ts
+++ b/src/lib/interfaces/conversion.ts
@@ -1,0 +1,18 @@
+import { Access } from './access';
+import { Subscription } from './subscription';
+import { Term } from './term';
+import { UserPayment } from './user-payment';
+import { UserPaymentInfo } from './user-payment-info';
+
+export interface Conversion {
+  term_conversion_id: string;
+  term: Term;
+  aid: string;
+  type: string;
+  user_access: Access;
+  create_date: number;
+  browser_id: string;
+  user_payment: UserPayment;
+  user_payment_info: UserPaymentInfo;
+  subscription: Subscription;
+}

--- a/src/lib/interfaces/export.ts
+++ b/src/lib/interfaces/export.ts
@@ -1,0 +1,13 @@
+export interface Export {
+  export_id: string;
+  export_name: string;
+  export_created: number;
+  export_updated?: number;
+  export_completed?: number;
+  export_percentage: number;
+  export_records: number;
+  export_status: string;
+  report_type: string;
+  export_repeatable: boolean;
+  filter_data: string;
+}

--- a/src/lib/interfaces/list.ts
+++ b/src/lib/interfaces/list.ts
@@ -1,0 +1,6 @@
+export interface List {
+  limit: number;
+  offset: number;
+  total: number;
+  count: number;
+}

--- a/src/lib/interfaces/resource.ts
+++ b/src/lib/interfaces/resource.ts
@@ -1,0 +1,20 @@
+export interface Resource {
+  rid: string;
+  aid: string;
+  deleted: boolean;
+  disabled: boolean;
+  create_date: number;
+  update_date: number;
+  publish_date: number;
+  name: string;
+  description: string;
+  image_url: string | null;
+  type: string;
+  type_label: string;
+  purchase_url: string | null;
+  resource_url: string | null;
+  external_id: string | null;
+  is_fbia_resource: boolean;
+  bundle_type: string;
+  bundle_type_label: string;
+}

--- a/src/lib/interfaces/subscription-list.ts
+++ b/src/lib/interfaces/subscription-list.ts
@@ -1,0 +1,9 @@
+import { Subscription } from './subscription';
+
+export interface SubscriptionList {
+  limit: number;
+  offset: number;
+  total: number;
+  count: number;
+  subscriptions: Subscription[];
+}

--- a/src/lib/interfaces/subscription-list.ts
+++ b/src/lib/interfaces/subscription-list.ts
@@ -1,9 +1,6 @@
+import { List } from './list';
 import { Subscription } from './subscription';
 
-export interface SubscriptionList {
-  limit: number;
-  offset: number;
-  total: number;
-  count: number;
+export interface SubscriptionList extends List {
   subscriptions: Subscription[];
 }

--- a/src/lib/interfaces/subscription.ts
+++ b/src/lib/interfaces/subscription.ts
@@ -1,0 +1,29 @@
+import { Resource } from './resource';
+import { Term } from './term';
+import { User } from './user';
+
+export interface Subscription {
+  subscription_id: string;
+  auto_renew: boolean;
+  next_bill_date: number;
+  payment_method: string;
+  user_payment_info_id: string;
+  upi_ext_customer_id: string;
+  upi_ext_customer_id_label: string | null;
+  billing_plan: string;
+  end_date: number;
+  cancelable: boolean;
+  cancelable_and_refundadle: boolean;
+  status: string;
+  status_name: string;
+  status_name_in_reports: string;
+  term: Term;
+  user: User;
+  resource: Resource;
+  start_date: number;
+  is_in_trial: boolean;
+  trial_period_end_date: number;
+  trial_amount: number;
+  trial_currency: string;
+  charge_count: number;
+}

--- a/src/lib/interfaces/term.ts
+++ b/src/lib/interfaces/term.ts
@@ -1,0 +1,15 @@
+import { Resource } from './resource';
+
+export interface Term {
+  aid: string;
+  term_id: string;
+  resource: Resource;
+  name: string;
+  description: string;
+  type: string;
+  type_name: string;
+  create_date: number;
+  update_date: number;
+  shared_account_count: number | null;
+  shared_redemption_url: number | null;
+}

--- a/src/lib/interfaces/user-payment-info.ts
+++ b/src/lib/interfaces/user-payment-info.ts
@@ -1,0 +1,10 @@
+export interface UserPaymentInfo {
+  user_payment_info_id: string;
+  description: string;
+  upi_nickname: string | null;
+  upi_number: string;
+  upi_expiration_month: number;
+  upi_expiration_year: number;
+  upi_postal_code: string | null;
+  upi_identifier: string;
+}

--- a/src/lib/interfaces/user-payment.ts
+++ b/src/lib/interfaces/user-payment.ts
@@ -1,0 +1,21 @@
+import { Subscription } from './subscription';
+import { Term } from './term';
+
+export interface UserPayment {
+  user_payment_id: string;
+  create_date: string;
+  renewal: boolean;
+  amount: number;
+  price: string;
+  currency: string;
+  subscription: Subscription;
+  payment_method: string;
+  upi_ext_customer_id: string;
+  upi_ext_customer_id_label: string | null;
+  term: Term;
+  refundable: boolean;
+  tax_billing_plan: string;
+  external_transaction_id: string;
+  tracking_id: string;
+  tax: number;
+}

--- a/src/lib/interfaces/user.ts
+++ b/src/lib/interfaces/user.ts
@@ -2,9 +2,10 @@ export interface User {
   first_name: string;
   last_name: string;
   email: string;
+  personal_name?: string | null;
   uid: string;
   image1: string;
   create_date: any;
-  reset_password_email_sent: boolean;
-  custom_fields: any;
+  reset_password_email_sent?: boolean;
+  custom_fields?: any;
 }

--- a/src/lib/publisher/conversion/index.ts
+++ b/src/lib/publisher/conversion/index.ts
@@ -7,10 +7,7 @@ import { PublisherConversionListResponse } from '../../interfaces/api-response';
 const ENDPOINT_PATH_PREFIX = '/publisher/conversion';
 
 export class Conversion {
-  private readonly piano: Piano;
-  constructor(piano: Piano) {
-    this.piano = piano;
-  }
+  constructor(private readonly piano: Piano) {}
 
   /**
    * Lists conversions for an app

--- a/src/lib/publisher/conversion/index.ts
+++ b/src/lib/publisher/conversion/index.ts
@@ -1,0 +1,40 @@
+import { Piano } from '../../piano';
+import { ConversionList as IConversionList } from '../../interfaces/conversion-list';
+import { httpRequest } from '../../utils/http-request';
+import { PublisherConversionListPrarams } from '../../interfaces/api-params';
+import { PublisherConversionListResponse } from '../../interfaces/api-response';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/conversion';
+
+export class Conversion {
+  private readonly piano: Piano;
+  constructor(piano: Piano) {
+    this.piano = piano;
+  }
+
+  /**
+   * Lists conversions for an app
+   *
+   * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fconversion~2Flist
+   */
+  public async list(
+    params: PublisherConversionListPrarams
+  ): Promise<IConversionList> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/list`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherConversionListResponse;
+
+    const { limit, offset, total, count, conversions } = apiResponse;
+
+    return {
+      limit,
+      offset,
+      total,
+      count,
+      conversions,
+    };
+  }
+}

--- a/src/lib/publisher/export/create/index.ts
+++ b/src/lib/publisher/export/create/index.ts
@@ -1,0 +1,9 @@
+import { Piano } from '../../../piano';
+import { TransactionsReport } from './transactions-report';
+
+export class Create {
+  public readonly transactionsReport: TransactionsReport;
+  constructor(piano: Piano) {
+    this.transactionsReport = new TransactionsReport(piano);
+  }
+}

--- a/src/lib/publisher/export/create/transactions-report/index.ts
+++ b/src/lib/publisher/export/create/transactions-report/index.ts
@@ -1,0 +1,30 @@
+import { PublisherExportCreateTransactionsReportV2Params } from '../../../../interfaces/api-params';
+import { PublisherExportCreateTransactionsReportV2Response } from '../../../../interfaces/api-response';
+import { Export as IExport } from '../../../../interfaces/export';
+import { httpRequest } from '../../../../utils/http-request';
+import { Piano } from '../../../../piano';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/export/create/transactionsReport';
+
+export class TransactionsReport {
+  constructor(private readonly piano: Piano) {}
+
+  /**
+   * Create downloadable transactions report with refunds and run it. Dates with time offset.
+   *
+   * @see https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fexport~2Fcreate~2FtransactionsReport~2Fv2
+   */
+
+  public async v2(
+    params: PublisherExportCreateTransactionsReportV2Params
+  ): Promise<IExport> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/v2`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherExportCreateTransactionsReportV2Response;
+
+    return apiResponse.export;
+  }
+}

--- a/src/lib/publisher/export/index.ts
+++ b/src/lib/publisher/export/index.ts
@@ -1,0 +1,9 @@
+import { Piano } from '../../piano';
+import { Create } from './create';
+
+export class Export {
+  public readonly create: Create;
+  constructor(piano: Piano) {
+    this.create = new Create(piano);
+  }
+}

--- a/src/lib/publisher/index.ts
+++ b/src/lib/publisher/index.ts
@@ -1,5 +1,6 @@
 import { Piano } from '../piano';
 import { Conversion } from './conversion';
+import { Export } from './export';
 import { Subscription } from './subscription';
 import { User } from './user';
 
@@ -7,10 +8,12 @@ export class Publisher {
   public readonly user: User;
   public readonly subscription: Subscription;
   public readonly conversion: Conversion;
+  public readonly export: Export;
 
   constructor(piano: Piano) {
     this.user = new User(piano);
     this.subscription = new Subscription(piano);
     this.conversion = new Conversion(piano);
+    this.export = new Export(piano);
   }
 }

--- a/src/lib/publisher/index.ts
+++ b/src/lib/publisher/index.ts
@@ -1,13 +1,16 @@
 import { Piano } from '../piano';
+import { Conversion } from './conversion';
 import { Subscription } from './subscription';
 import { User } from './user';
 
 export class Publisher {
   public readonly user: User;
   public readonly subscription: Subscription;
+  public readonly conversion: Conversion;
 
   constructor(piano: Piano) {
     this.user = new User(piano);
     this.subscription = new Subscription(piano);
+    this.conversion = new Conversion(piano);
   }
 }

--- a/src/lib/publisher/index.ts
+++ b/src/lib/publisher/index.ts
@@ -1,10 +1,13 @@
-import { Piano } from "../piano";
-import { User } from "./user";
+import { Piano } from '../piano';
+import { Subscription } from './subscription';
+import { User } from './user';
 
 export class Publisher {
   public readonly user: User;
+  public readonly subscription: Subscription;
 
   constructor(piano: Piano) {
     this.user = new User(piano);
+    this.subscription = new Subscription(piano);
   }
 }

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -1,0 +1,40 @@
+import { Piano } from '../../piano';
+import { PublisherSubscriptionListPrarams } from '../../interfaces/api-params';
+import { SubscriptionList } from '../../interfaces/subscription-list';
+import { httpRequest } from '../../utils/http-request';
+import { PublisherSubscriptionListResponse } from '../../interfaces/api-response';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/subscription';
+
+export class Subscription {
+  private readonly piano: Piano;
+  constructor(piano: Piano) {
+    this.piano = piano;
+  }
+
+  /**
+   * Lists subscriptions.
+   *
+   * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fsubscription~2Flist
+   */
+  public async list(
+    params: PublisherSubscriptionListPrarams
+  ): Promise<SubscriptionList> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/list`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherSubscriptionListResponse;
+
+    const { limit, offset, total, count, subscriptions } = apiResponse;
+
+    return {
+      limit,
+      offset,
+      total,
+      count,
+      subscriptions,
+    };
+  }
+}

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -1,6 +1,6 @@
 import { Piano } from '../../piano';
 import { PublisherSubscriptionListPrarams } from '../../interfaces/api-params';
-import { SubscriptionList } from '../../interfaces/subscription-list';
+import { SubscriptionList as ISubscriptionList } from '../../interfaces/subscription-list';
 import { httpRequest } from '../../utils/http-request';
 import { PublisherSubscriptionListResponse } from '../../interfaces/api-response';
 
@@ -19,7 +19,7 @@ export class Subscription {
    */
   public async list(
     params: PublisherSubscriptionListPrarams
-  ): Promise<SubscriptionList> {
+  ): Promise<ISubscriptionList> {
     const apiResponse = (await httpRequest(
       'get',
       `${ENDPOINT_PATH_PREFIX}/list`,

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -7,10 +7,7 @@ import { PublisherSubscriptionListResponse } from '../../interfaces/api-response
 const ENDPOINT_PATH_PREFIX = '/publisher/subscription';
 
 export class Subscription {
-  private readonly piano: Piano;
-  constructor(piano: Piano) {
-    this.piano = piano;
-  }
+  constructor(private readonly piano: Piano) {}
 
   /**
    * Lists subscriptions.


### PR DESCRIPTION
I added some apis related to reporting features of Piano API.
- [Lists conversions for an app](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fconversion~2Flist)
- [Lists subscriptions.](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fsubscription~2Flist)
- [Create downloadable transactions report with refunds and run it. Dates with time offset.](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fexport~2Fcreate~2FtransactionsReport~2Fv2)