### PR TITLE
Add report exporting apis

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -146,6 +146,10 @@ export interface PublisherExportGetParams {
   export_id: string;
 }
 
+export interface PublisherExportDownloadParams {
+  export_id: string;
+}
+
 export interface PublisherExportCreateTransactionsReportV2Params {
   export_name: string;
   transactions_type?: 'all' | 'purchases' | 'refunds';

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -151,3 +151,29 @@ export interface PublisherExportCreateTransactionsReportV2Params {
   date_from?: string;
   date_to?: string;
 }
+
+export interface PublisherExportCreateSubscriptionDetailsReportV2Params {
+  export_name: string;
+  q?: string;
+  search_new_subscriptions?: boolean;
+  new_subscriptions_created_from?: string;
+  new_subscriptions_created_to?: string;
+  search_active_now_subscriptions?: boolean;
+  active_now_subscriptions_statuses?: any[];
+  search_inactive_subscriptions?: boolean;
+  inactive_subscriptions_statuses?: any[];
+  subscriptions_inactive_from?: string;
+  subscriptions_inactive_to?: string;
+  search_updated_subscriptions?: boolean;
+  updated_subscriptions_statuses?: any[];
+  subscriptions_updated_from?: string;
+  subscriptions_updated_to?: string;
+  search_auto_renewing_subscriptions?: boolean;
+  subscriptions_auto_renewing?: boolean;
+  search_subscriptions_by_next_billing_date?: boolean;
+  subscriptions_next_billing_date_from?: string;
+  subscriptions_next_billing_date_to?: string;
+  search_subscriptions_by_terms?: boolean;
+  subscriptions_terms?: any[];
+  subscriptions_term_types?: any[];
+}

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -142,6 +142,10 @@ export interface PublisherConversionListPrarams {
   limit: number;
 }
 
+export interface PublisherExportGetParams {
+  export_id: string;
+}
+
 export interface PublisherExportCreateTransactionsReportV2Params {
   export_name: string;
   transactions_type?: 'all' | 'purchases' | 'refunds';

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -54,3 +54,8 @@ export interface PublisherExportCreateTransactionsReportV2Response
   extends ApiResponse {
   export: Export;
 }
+
+export interface PublisherExportCreateSubscriptionDetailsReportV2Response
+  extends ApiResponse {
+  export: Export;
+}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -53,6 +53,9 @@ export interface PublisherConversionListResponse
 export interface PublisherExportGetResponse extends ApiResponse {
   export: Export;
 }
+export interface PublisherExportDownloadResponse extends ApiResponse {
+  data: string;
+}
 
 export interface PublisherExportCreateTransactionsReportV2Response
   extends ApiResponse {

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -50,6 +50,10 @@ export interface PublisherConversionListResponse
   extends ApiResponse,
     ConversionList {}
 
+export interface PublisherExportGetResponse extends ApiResponse {
+  export: Export;
+}
+
 export interface PublisherExportCreateTransactionsReportV2Response
   extends ApiResponse {
   export: Export;

--- a/src/lib/publisher/export/create/index.ts
+++ b/src/lib/publisher/export/create/index.ts
@@ -1,9 +1,12 @@
 import { Piano } from '../../../piano';
+import { SubscriptionDetailsReport } from './subscription-details-report';
 import { TransactionsReport } from './transactions-report';
 
 export class Create {
   public readonly transactionsReport: TransactionsReport;
+  public readonly subscriptionDetailsReport: SubscriptionDetailsReport;
   constructor(piano: Piano) {
     this.transactionsReport = new TransactionsReport(piano);
+    this.subscriptionDetailsReport = new SubscriptionDetailsReport(piano);
   }
 }

--- a/src/lib/publisher/export/create/subscription-details-report/index.ts
+++ b/src/lib/publisher/export/create/subscription-details-report/index.ts
@@ -1,0 +1,31 @@
+import { Export as IExport } from '../../../../interfaces/export';
+import { httpRequest } from '../../../../utils/http-request';
+import { Piano } from '../../../../piano';
+import { PublisherExportCreateSubscriptionDetailsReportV2Params } from '../../../../interfaces/api-params';
+import { PublisherExportCreateSubscriptionDetailsReportV2Response } from '../../../../interfaces/api-response';
+
+const ENDPOINT_PATH_PREFIX =
+  '/publisher/export/create/subscriptionDetailsReport';
+
+export class SubscriptionDetailsReport {
+  constructor(private readonly piano: Piano) {}
+
+  /**
+   * Create subscription details report with account of timezone
+   *
+   * @see https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fexport~2Fcreate~2FsubscriptionDetailsReport~2Fv2
+   */
+
+  public async v2(
+    params: PublisherExportCreateSubscriptionDetailsReportV2Params
+  ): Promise<IExport> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/v2`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherExportCreateSubscriptionDetailsReportV2Response;
+
+    return apiResponse.export;
+  }
+}

--- a/src/lib/publisher/export/index.ts
+++ b/src/lib/publisher/export/index.ts
@@ -1,9 +1,32 @@
+import { PublisherExportGetParams } from '../../interfaces/api-params';
+import { PublisherExportGetResponse } from '../../interfaces/api-response';
+import { Export as IExport } from '../../interfaces/export';
 import { Piano } from '../../piano';
+import { httpRequest } from '../../utils/http-request';
 import { Create } from './create';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/export';
 
 export class Export {
   public readonly create: Create;
-  constructor(piano: Piano) {
+  constructor(private readonly piano: Piano) {
     this.create = new Create(piano);
+  }
+
+  /**
+   * Get report
+   *
+   * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fexport~2Fget
+   */
+
+  public async get(params: PublisherExportGetParams): Promise<IExport> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/get`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherExportGetResponse;
+
+    return apiResponse.export;
   }
 }

--- a/src/lib/publisher/export/index.ts
+++ b/src/lib/publisher/export/index.ts
@@ -1,5 +1,11 @@
-import { PublisherExportGetParams } from '../../interfaces/api-params';
-import { PublisherExportGetResponse } from '../../interfaces/api-response';
+import {
+  PublisherExportDownloadParams,
+  PublisherExportGetParams,
+} from '../../interfaces/api-params';
+import {
+  PublisherExportDownloadResponse,
+  PublisherExportGetResponse,
+} from '../../interfaces/api-response';
 import { Export as IExport } from '../../interfaces/export';
 import { Piano } from '../../piano';
 import { httpRequest } from '../../utils/http-request';
@@ -28,5 +34,24 @@ export class Export {
     )) as PublisherExportGetResponse;
 
     return apiResponse.export;
+  }
+
+  /**
+   * Get URL for download
+   *
+   * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fexport~2Fdownload
+   */
+
+  public async download(
+    params: PublisherExportDownloadParams
+  ): Promise<string> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/download`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherExportDownloadResponse;
+
+    return apiResponse.data;
   }
 }


### PR DESCRIPTION
I added apis related to exporting reports.

- [Create subscription details report with account of timezone](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fexport~2Fcreate~2FsubscriptionDetailsReport~2Fv2)
- [Get report](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fexport~2Fget)
- [Get URL for download](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fexport~2Fdownload)