### PR TITLE
Add publisher subscription get api

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -125,6 +125,10 @@ export interface PublisherUserAccessListParams {
   cross_app?: boolean;
 }
 
+export interface PublisherSubscriptionGetParams {
+  subscription_id: string;
+}
+
 export interface PublisherSubscriptionListParams {
   uid?: string;
   type?: string;

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -3,6 +3,7 @@ import { Access } from './access';
 import { UserSubscriptionList } from './user-subscription-list';
 import { ConversionList } from './conversion-list';
 import { Export } from './export';
+import { UserSubscription } from './user-subscription';
 
 export interface ApiResponse {
   code: number;
@@ -40,6 +41,10 @@ export interface PublisherUserAccessListResponse extends ApiResponse {
 
 export interface PublisherUserAccessActiveCountResponse extends ApiResponse {
   data: number;
+}
+
+export interface PublisherSubscriptionGetResponse extends ApiResponse {
+  subscription: UserSubscription
 }
 
 export interface PublisherSubscriptionListResponse

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -1,19 +1,42 @@
 import { Piano } from '../../piano';
 import {
+  PublisherSubscriptionGetParams,
   PublisherSubscriptionListParams,
   PublisherSubscriptionUpdateParams,
 } from '../../interfaces/api-params';
 import { UserSubscriptionList as IUserSubscriptionList } from '../../interfaces/user-subscription-list';
 import { httpRequest } from '../../utils/http-request';
 import {
+  PublisherSubscriptionGetResponse,
   PublisherSubscriptionListResponse,
   PublisherSubscriptionUpdateResponse,
 } from '../../interfaces/api-response';
+import { UserSubscription as IUserSubscription } from '../../interfaces/user-subscription';
 
 const ENDPOINT_PATH_PREFIX = '/publisher/subscription';
 
 export class Subscription {
   constructor(private readonly piano: Piano) {}
+
+  /**
+   * Gets a subscription.
+   *
+   * @see https://docs.piano.io/api/?endpoint=get~2F~2Fpublisher~2Fsubscription~2Fget
+   */
+  public async get(
+    params: PublisherSubscriptionGetParams
+  ): Promise<IUserSubscription> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/get`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherSubscriptionGetResponse;
+
+    const { subscription } = apiResponse;
+
+    return subscription;
+  }
 
   /**
    * Lists subscriptions.


### PR DESCRIPTION
This PR adds support for the [/publisher/subscription/get](https://docs.piano.io/api/?endpoint=get~2F~2Fpublisher~2Fsubscription~2Fget) API. 

All necessary types were already defined in the codebase so this was a fairly straightforward addition.

I tested the implementation and was able to successfully retrieve information for a few subscriptions.