### PR TITLE
Remove term property from /publisher/user/access endpoints

### DIFF
--- a/src/lib/interfaces/access-dto.ts
+++ b/src/lib/interfaces/access-dto.ts
@@ -1,0 +1,14 @@
+import { Resource } from './resource';
+import { User } from './user';
+
+export interface AccessDTO {
+  access_id: string;
+  parent_access_id: string | null;
+  granted: boolean;
+  revoked: boolean;
+  resource: Resource;
+  user: User;
+  expire_date: number | null;
+  start_date: number;
+  can_revoke_access: boolean;
+}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -1,9 +1,9 @@
 import { User } from './user';
-import { Access } from './access';
 import { UserSubscriptionList } from './user-subscription-list';
 import { ConversionList } from './conversion-list';
 import { Export } from './export';
 import { UserSubscription } from './user-subscription';
+import { AccessDTO } from './access-dto';
 
 export interface ApiResponse {
   code: number;
@@ -32,11 +32,11 @@ export interface PublisherUserUpdateResponse extends ApiResponse {
 }
 
 export interface PublisherUserAccessCheckResponse extends ApiResponse {
-  access: Access;
+  access: AccessDTO;
 }
 
 export interface PublisherUserAccessListResponse extends ApiResponse {
-  accesses: Access[];
+  accesses: AccessDTO[];
 }
 
 export interface PublisherUserAccessActiveCountResponse extends ApiResponse {

--- a/src/lib/publisher/user/access/index.ts
+++ b/src/lib/publisher/user/access/index.ts
@@ -1,7 +1,6 @@
 import { Piano } from '../../../piano';
 import { httpRequest } from '../../../utils/http-request';
 import { Active } from './active';
-import { Access as IAccess } from '../../../interfaces/access';
 import {
   PublisherUserAccessCheckParams,
   PublisherUserAccessListParams,
@@ -10,6 +9,7 @@ import {
   PublisherUserAccessCheckResponse,
   PublisherUserAccessListResponse,
 } from '../../../interfaces/api-response';
+import { AccessDTO } from '../../../interfaces/access-dto';
 
 const ENDPOINT_PATH_PREFIX = '/publisher/user/access';
 
@@ -27,7 +27,7 @@ export class Access {
    *
    * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fuser~2Faccess~2Fcheck
    */
-  public async check(params: PublisherUserAccessCheckParams): Promise<IAccess> {
+  public async check(params: PublisherUserAccessCheckParams): Promise<AccessDTO> {
     const apiResponse = (await httpRequest(
       'post',
       `${ENDPOINT_PATH_PREFIX}/check`,
@@ -43,7 +43,7 @@ export class Access {
    *
    * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fuser~2Faccess~2Flist
    */
-  public async list(params: PublisherUserAccessListParams): Promise<IAccess[]> {
+  public async list(params: PublisherUserAccessListParams): Promise<AccessDTO[]> {
     const apiResponse = (await httpRequest(
       'get',
       `${ENDPOINT_PATH_PREFIX}/list`,


### PR DESCRIPTION
This PR removes the `term` property from the response types in the following endpoints, in anticipation of API changes Piano has announced will take effect on 3 October 2022:
- [/publisher/user/access/list](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fuser~2Faccess~2Flist)
- [/publisher/user/access/check](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fuser~2Faccess~2Fcheck)

The `Access` interface previously used for those endpoints' responses continues to be used for the `user_access` property of `TermConversionDTO`, used in [/publisher/conversion/list](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fconversion~2Flist). Piano's announcement states that `Term` properties will continue to be included in its responses.

In order to modify the response type only for `/publisher/user/access/list` and `../check`, I created a new interface `AccessDTO`, which is identical to `Access` except that the `term` property has been removed. This is consistent with the naming in the Piano documentation, where `AccessDTO` is listed only for the five endpoints mentioned in their announcement.