### PR TITLE
Add publisher term change apis

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -203,3 +203,7 @@ export interface PublisherTermChangeGetSubscriptionUpgradeStatusParams {
   uid: string;
   subscription_id: string;
 }
+
+export interface PublisherTermChangeCancelParams {
+  subscription_from: string;
+}

--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -198,3 +198,8 @@ export interface PublisherExportCreateSubscriptionDetailsReportV2Params {
   subscriptions_terms?: any[];
   subscriptions_term_types?: any[];
 }
+
+export interface PublisherTermChangeGetSubscriptionUpgradeStatusParams {
+  uid: string;
+  subscription_id: string;
+}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -4,6 +4,7 @@ import { ConversionList } from './conversion-list';
 import { Export } from './export';
 import { UserSubscription } from './user-subscription';
 import { AccessDTO } from './access-dto';
+import { SubscriptionUpgradeStatus } from './subscription-upgrade-status';
 
 export interface ApiResponse {
   code: number;
@@ -75,3 +76,8 @@ export interface PublisherExportCreateSubscriptionDetailsReportV2Response
   extends ApiResponse {
   export: Export;
 }
+
+export interface PublisherTermChangeGetSubscriptionUpgradeStatusResponse
+  extends ApiResponse {
+    subscription_upgrade_status: SubscriptionUpgradeStatus | undefined;
+  }

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -81,3 +81,8 @@ export interface PublisherTermChangeGetSubscriptionUpgradeStatusResponse
   extends ApiResponse {
     subscription_upgrade_status: SubscriptionUpgradeStatus | undefined;
   }
+
+export interface PublisherTermChangeCancelResponse
+  extends ApiResponse {
+    data: boolean;
+  }

--- a/src/lib/interfaces/subscription-upgrade-status.ts
+++ b/src/lib/interfaces/subscription-upgrade-status.ts
@@ -1,3 +1,10 @@
+export enum SubscriptionUpgradeStatusFlag {
+  PENDING = 0,
+  FAILED = 1,
+  FAILED_CLOSED = 2,
+  SUSPENDED = 3,
+}
+
 export interface SubscriptionUpgradeStatus {
   from_term_name: string;
   to_term_name: string;
@@ -8,7 +15,7 @@ export interface SubscriptionUpgradeStatus {
   create_date_to: string;
   billing_plan_to: string;
   billing_plan_from: string;
-  status: number;
+  status: SubscriptionUpgradeStatusFlag;
   error_message: string;
   prorate_amount: string;
   prorate_refund_amount: string;

--- a/src/lib/interfaces/subscription-upgrade-status.ts
+++ b/src/lib/interfaces/subscription-upgrade-status.ts
@@ -1,0 +1,15 @@
+export interface SubscriptionUpgradeStatus {
+  from_term_name: string;
+  to_term_name: string;
+  from_term_id: string;
+  to_term_id: string;
+  change_date: string;
+  create_date_from: string;
+  create_date_to: string;
+  billing_plan_to: string;
+  billing_plan_from: string;
+  status: number;
+  error_message: string;
+  prorate_amount: string;
+  prorate_refund_amount: string;
+}

--- a/src/lib/publisher/index.ts
+++ b/src/lib/publisher/index.ts
@@ -2,6 +2,7 @@ import { Piano } from '../piano';
 import { Conversion } from './conversion';
 import { Export } from './export';
 import { Subscription } from './subscription';
+import { Term } from './term';
 import { User } from './user';
 
 export class Publisher {
@@ -9,11 +10,13 @@ export class Publisher {
   public readonly subscription: Subscription;
   public readonly conversion: Conversion;
   public readonly export: Export;
+  public readonly term: Term;
 
   constructor(piano: Piano) {
     this.user = new User(piano);
     this.subscription = new Subscription(piano);
     this.conversion = new Conversion(piano);
     this.export = new Export(piano);
+    this.term = new Term(piano);
   }
 }

--- a/src/lib/publisher/term/change/index.ts
+++ b/src/lib/publisher/term/change/index.ts
@@ -1,0 +1,32 @@
+import {
+  PublisherTermChangeGetSubscriptionUpgradeStatusParams
+} from '../../../interfaces/api-params'
+import {
+  PublisherTermChangeGetSubscriptionUpgradeStatusResponse
+} from '../../../interfaces/api-response'
+import { SubscriptionUpgradeStatus as ISubscriptionUpgradeStatus } from '../../../interfaces/subscription-upgrade-status';
+import { Piano } from '../../../piano';
+import { httpRequest } from '../../../utils/http-request';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/term/change';
+
+export class Change {
+  constructor (private readonly piano: Piano) {}
+
+  /**
+   * Get upgrade status of subscription
+   *
+   * @see https://docs.piano.io/api/?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2FgetSubscriptionUpgradeStatus
+   */
+
+  public async getSubscriptionUpgradeStatus(params: PublisherTermChangeGetSubscriptionUpgradeStatusParams): Promise<ISubscriptionUpgradeStatus | undefined> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/getSubscriptionUpgradeStatus`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherTermChangeGetSubscriptionUpgradeStatusResponse;
+
+    return apiResponse.subscription_upgrade_status;
+  }
+}

--- a/src/lib/publisher/term/change/index.ts
+++ b/src/lib/publisher/term/change/index.ts
@@ -20,7 +20,6 @@ export class Change {
    *
    * @see https://docs.piano.io/api/?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2FgetSubscriptionUpgradeStatus
    */
-
   public async getSubscriptionUpgradeStatus(params: PublisherTermChangeGetSubscriptionUpgradeStatusParams): Promise<ISubscriptionUpgradeStatus | undefined> {
     const apiResponse = (await httpRequest(
       'post',

--- a/src/lib/publisher/term/change/index.ts
+++ b/src/lib/publisher/term/change/index.ts
@@ -1,7 +1,9 @@
 import {
+  PublisherTermChangeCancelParams,
   PublisherTermChangeGetSubscriptionUpgradeStatusParams
 } from '../../../interfaces/api-params'
 import {
+  PublisherTermChangeCancelResponse,
   PublisherTermChangeGetSubscriptionUpgradeStatusResponse
 } from '../../../interfaces/api-response'
 import { SubscriptionUpgradeStatus as ISubscriptionUpgradeStatus } from '../../../interfaces/subscription-upgrade-status';
@@ -28,5 +30,21 @@ export class Change {
     )) as PublisherTermChangeGetSubscriptionUpgradeStatusResponse;
 
     return apiResponse.subscription_upgrade_status;
+  }
+
+  /**
+   * Cancel a pending term change for a subscription
+   *
+   * @see https://docs.piano.io/api/?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2Fcancel
+   */
+  public async cancel(params: PublisherTermChangeCancelParams): Promise<boolean> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/cancel`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherTermChangeCancelResponse;
+
+    return apiResponse.data;
   }
 }

--- a/src/lib/publisher/term/index.ts
+++ b/src/lib/publisher/term/index.ts
@@ -1,0 +1,9 @@
+import { Piano } from '../../piano';
+import { Change } from './change';
+
+export class Term {
+  public readonly change: Change;
+  constructor(private readonly piano: Piano) {
+    this.change = new Change(piano);
+  }
+}


### PR DESCRIPTION
This PR adds implementations for the following endpoints:
- [/publisher/term/change/getSubscriptionUpgradeStatus](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2FgetSubscriptionUpgradeStatus) 
- [/publisher/term/change/cancel](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2Fcancel)

I tested this implementation and was able to retrieve the upgrade status for subscriptions and cancel pending upgrades.