### PR TITLE
Add publisher subscription cancel api

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -149,6 +149,11 @@ export interface PublisherSubscriptionUpdateParams {
   user_address_id?: boolean;
 }
 
+export interface PublisherSubscriptionCancelParams {
+  subscription_id: string;
+  refund_last_payment: boolean;
+}
+
 export interface PublisherConversionListParams {
   uid?: string;
   offset: number;

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -56,6 +56,10 @@ export interface PublisherSubscriptionUpdateResponse extends ApiResponse {
   data: boolean;
 }
 
+export interface PublisherSubscriptionCancelResponse extends ApiResponse {
+  data: boolean;
+}
+
 export interface PublisherConversionListResponse
   extends ApiResponse,
     ConversionList {}

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -1,5 +1,6 @@
 import { Piano } from '../../piano';
 import {
+  PublisherSubscriptionCancelParams,
   PublisherSubscriptionGetParams,
   PublisherSubscriptionListParams,
   PublisherSubscriptionUpdateParams,
@@ -7,6 +8,7 @@ import {
 import { UserSubscriptionList as IUserSubscriptionList } from '../../interfaces/user-subscription-list';
 import { httpRequest } from '../../utils/http-request';
 import {
+  PublisherSubscriptionCancelResponse,
   PublisherSubscriptionGetResponse,
   PublisherSubscriptionListResponse,
   PublisherSubscriptionUpdateResponse,
@@ -78,6 +80,26 @@ export class Subscription {
       this.piano.mergeParams(params),
       this.piano.environment
     )) as PublisherSubscriptionUpdateResponse;
+
+    const { data } = apiResponse;
+
+    return data;
+  }
+
+  /**
+   * Cancels a subscription.
+   *
+   * @see https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fsubscription~2Fcancel
+   */
+  public async cancel(
+    params: PublisherSubscriptionCancelParams
+  ): Promise<boolean> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/cancel`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherSubscriptionCancelResponse;
 
     const { data } = apiResponse;
 


### PR DESCRIPTION
This PR adds an implementation of the [/publisher/subscription/cancel](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fsubscription~2Fcancel) endpoint.

I tested this API and was able to successfully cancel subscriptions. I also checked that the last payment was refunded if `refund_last_payment` was true, and that no refund occurred otherwise.