### PR TITLE
Add publisher subscription search api

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -1,4 +1,8 @@
 type OrderDirection = 'asc' | 'desc';
+type ActiveNowSubscriptionStatus = 'active' | 'failedAndRetry';
+type InactiveSubscriptionStatus = 'cancelled' | 'paymentFailure' | 'expired' | 'completed' | 'upgraded';
+type UpdatedSubscriptionStatus = 'renewed';
+type SubscriptionTermType = 'payment' | 'external' | 'gift';
 
 export interface PublisherUserCreateParams {
   uid: string;
@@ -141,6 +145,35 @@ export interface PublisherSubscriptionListParams {
   status?: string;
 }
 
+export interface PublisherSubscriptionSearchParams {
+  q?: string;
+  offset: number;
+  limit: number;
+  order_by?: string;
+  order_direction?: OrderDirection;
+  search_new_subscriptions?: boolean;
+  new_subscriptions_created_from?: string;
+  new_subscriptions_created_to?: string;
+  search_active_now_subscriptions?: boolean;
+  active_now_subscriptions_statuses?: ActiveNowSubscriptionStatus[];
+  search_inactive_subscriptions?: boolean;
+  inactive_subscriptions_statuses?: InactiveSubscriptionStatus[];
+  subscriptions_inactive_from?: string;
+  subscriptions_inactive_to?: string;
+  search_updated_subscriptions?: boolean;
+  updated_subscriptions_statuses?: UpdatedSubscriptionStatus[];
+  subscriptions_updated_from?: string;
+  subscriptions_updated_to?: string;
+  search_auto_renewing_subscriptions?: boolean;
+  subscriptions_auto_renewing?: boolean;
+  search_subscriptions_by_next_billing_date?: boolean;
+  subscriptions_next_billing_date_from?: string;
+  subscriptions_next_billing_date_to?: string;
+  search_subscriptions_by_terms?: boolean;
+  subscriptions_terms?: string[];
+  subscriptions_term_types?: SubscriptionTermType[];
+}
+
 export interface PublisherSubscriptionUpdateParams {
   subscription_id: string;
   next_bill_date?: string;
@@ -185,13 +218,13 @@ export interface PublisherExportCreateSubscriptionDetailsReportV2Params {
   new_subscriptions_created_from?: string;
   new_subscriptions_created_to?: string;
   search_active_now_subscriptions?: boolean;
-  active_now_subscriptions_statuses?: any[];
+  active_now_subscriptions_statuses?: ActiveNowSubscriptionStatus[];
   search_inactive_subscriptions?: boolean;
-  inactive_subscriptions_statuses?: any[];
+  inactive_subscriptions_statuses?: InactiveSubscriptionStatus[];
   subscriptions_inactive_from?: string;
   subscriptions_inactive_to?: string;
   search_updated_subscriptions?: boolean;
-  updated_subscriptions_statuses?: any[];
+  updated_subscriptions_statuses?: UpdatedSubscriptionStatus[];
   subscriptions_updated_from?: string;
   subscriptions_updated_to?: string;
   search_auto_renewing_subscriptions?: boolean;
@@ -200,8 +233,8 @@ export interface PublisherExportCreateSubscriptionDetailsReportV2Params {
   subscriptions_next_billing_date_from?: string;
   subscriptions_next_billing_date_to?: string;
   search_subscriptions_by_terms?: boolean;
-  subscriptions_terms?: any[];
-  subscriptions_term_types?: any[];
+  subscriptions_terms?: string[];
+  subscriptions_term_types?: SubscriptionTermType[];
 }
 
 export interface PublisherTermChangeGetSubscriptionUpgradeStatusParams {

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -5,6 +5,7 @@ import { Export } from './export';
 import { UserSubscription } from './user-subscription';
 import { AccessDTO } from './access-dto';
 import { SubscriptionUpgradeStatus } from './subscription-upgrade-status';
+import { SubscriptionLogItemList } from './subscription-log-item-list';
 
 export interface ApiResponse {
   code: number;
@@ -51,6 +52,10 @@ export interface PublisherSubscriptionGetResponse extends ApiResponse {
 export interface PublisherSubscriptionListResponse
   extends ApiResponse,
     UserSubscriptionList {}
+
+export interface PublisherSubscriptionLogItemListResponse
+  extends ApiResponse,
+    SubscriptionLogItemList {}
 
 export interface PublisherSubscriptionUpdateResponse extends ApiResponse {
   data: boolean;

--- a/src/lib/interfaces/subscription-log-item-list.ts
+++ b/src/lib/interfaces/subscription-log-item-list.ts
@@ -1,0 +1,6 @@
+import { List } from './list';
+import { SubscriptionLogItem } from './subscription-log-item';
+
+export interface SubscriptionLogItemList extends List {
+  subscriptionLogItems: SubscriptionLogItem[];
+}

--- a/src/lib/interfaces/subscription-log-item.ts
+++ b/src/lib/interfaces/subscription-log-item.ts
@@ -1,0 +1,14 @@
+import { Term } from './term';
+
+export interface SubscriptionLogItem {
+  subscription_id: string;
+  email: string;
+  uid: string;
+  rid: string;
+  term: Term;
+  billing_plan: string;
+  start_date: number;
+  next_bill_date: number;
+  status_name_in_reports: string;
+  child_access: string;
+}

--- a/src/lib/piano.ts
+++ b/src/lib/piano.ts
@@ -6,6 +6,7 @@ export * from './interfaces/api-params';
 export * from './interfaces/api-response';
 export * from './interfaces/client';
 export * from './interfaces/user';
+export * from './interfaces/subscription-log-item';
 
 export class Piano {
   private readonly aid: string;

--- a/src/lib/publisher/subscription/index.ts
+++ b/src/lib/publisher/subscription/index.ts
@@ -3,14 +3,17 @@ import {
   PublisherSubscriptionCancelParams,
   PublisherSubscriptionGetParams,
   PublisherSubscriptionListParams,
+  PublisherSubscriptionSearchParams,
   PublisherSubscriptionUpdateParams,
 } from '../../interfaces/api-params';
 import { UserSubscriptionList as IUserSubscriptionList } from '../../interfaces/user-subscription-list';
+import { SubscriptionLogItemList as ISubscriptionLogItemList } from '../../interfaces/subscription-log-item-list';
 import { httpRequest } from '../../utils/http-request';
 import {
   PublisherSubscriptionCancelResponse,
   PublisherSubscriptionGetResponse,
   PublisherSubscriptionListResponse,
+  PublisherSubscriptionLogItemListResponse,
   PublisherSubscriptionUpdateResponse,
 } from '../../interfaces/api-response';
 import { UserSubscription as IUserSubscription } from '../../interfaces/user-subscription';
@@ -63,6 +66,32 @@ export class Subscription {
       total,
       count,
       subscriptions,
+    };
+  }
+
+  /**
+   * Searches subscriptions.
+   *
+   * @see https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fsubscription~2Fsearch
+   */
+  public async search(
+    params: PublisherSubscriptionSearchParams
+  ): Promise<ISubscriptionLogItemList> {
+    const apiResponse = (await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/search`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherSubscriptionLogItemListResponse;
+
+    const { limit, offset, total, count, subscriptionLogItems } = apiResponse;
+
+    return {
+      limit,
+      offset,
+      total,
+      count,
+      subscriptionLogItems,
     };
   }
 


### PR DESCRIPTION
This PR adds an implementation of the [/publication/subscription/search](https://docs.piano.io/api?endpoint=get~2F~2Fpublisher~2Fsubscription~2Fsearch) endpoint.

I tested the implementation by running a number of searches and checking to see that the results made sense. I wasn't able to test every single parameter, but I did test all the possible values for `ActiveNowSubscriptionStatus`, `InactiveSubscriptionStatus`, `UpdatedSubscriptionStatus`, and `SubscriptionTermType`.

Since [/publisher/export/create/subscriptionDetailsReport](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fexport~2Fcreate~2FsubscriptionDetailsReport) uses the same parameters, I used the above types to make the definitions of its parameters more precise as well.
