### PR TITLE
Fix handling of array parameters

### DIFF
--- a/src/lib/utils/http-request.ts
+++ b/src/lib/utils/http-request.ts
@@ -37,12 +37,23 @@ export const httpRequest = async (
 
   const endpoint = `${baseUrl}${path}`;
 
+  const urlParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(requestParams)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        urlParams.append(key, entry);
+      }
+    } else {
+      urlParams.append(key, value as string);
+    }
+  }
+
   const response =
     method == 'get'
-      ? await fetch(`${endpoint}?${new URLSearchParams(requestParams)}`)
+      ? await fetch(`${endpoint}?${urlParams}`)
       : await fetch(endpoint, {
           method: 'POST',
-          body: new URLSearchParams(requestParams),
+          body: urlParams,
         });
 
   const apiResponse = (await response.json()) as ApiResponse;


### PR DESCRIPTION
This PR fixes an issue with the handling of array parameters when making requests against the Piano API.

For example, if the values `['bar1', 'bar2']` are specified for the parameter `foo`, the current implementation concatenates the values of the array with a (URL-encoded) comma, like `?foo=bar1%2Cbar2`. The Piano API just interprets this as a single value, resulting in errors and other undesired results.

This PR changes the implementation so that each value in the array is passed separately as another instance of the parameter, like `?foo=bar1&foo=bar2`. This is the format the Piano API expects.

I tested this implementation by making requests against the `/publisher/subscription/search` API that I implemented in #19, and making sure that the results from passing multiple values to array parameters were as expected.

I also confirmed that anything other than an array parameter was encoded in the same way in the new implementation as in the old one. Specifically, I checked the following:
- arrays with just one element
- strings
- numbers
- booleans
