### PR TITLE
Add publisher export run api

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -197,6 +197,10 @@ export interface PublisherExportGetParams {
   export_id: string;
 }
 
+export interface PublisherExportRunParams {
+  export_id: string;
+}
+
 export interface PublisherExportDownloadParams {
   export_id: string;
 }

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -72,6 +72,11 @@ export interface PublisherConversionListResponse
 export interface PublisherExportGetResponse extends ApiResponse {
   export: Export;
 }
+
+export interface PublisherExportRunResponse extends ApiResponse {
+  data: boolean;
+}
+
 export interface PublisherExportDownloadResponse extends ApiResponse {
   data: string;
 }

--- a/src/lib/publisher/export/index.ts
+++ b/src/lib/publisher/export/index.ts
@@ -1,10 +1,12 @@
 import {
   PublisherExportDownloadParams,
   PublisherExportGetParams,
+  PublisherExportRunParams,
 } from '../../interfaces/api-params';
 import {
   PublisherExportDownloadResponse,
   PublisherExportGetResponse,
+  PublisherExportRunResponse,
 } from '../../interfaces/api-response';
 import { Export as IExport } from '../../interfaces/export';
 import { Piano } from '../../piano';
@@ -34,6 +36,23 @@ export class Export {
     )) as PublisherExportGetResponse;
 
     return apiResponse.export;
+  }
+
+  /**
+   * Rerun report generation
+   *
+   * @see https://docs.piano.io/api/?endpoint=get~2F~2Fpublisher~2Fexport~2Frun
+   */
+
+  public async run(params: PublisherExportRunParams): Promise<boolean> {
+    const apiResponse =(await httpRequest(
+      'get',
+      `${ENDPOINT_PATH_PREFIX}/run`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherExportRunResponse;
+
+    return apiResponse.data;
   }
 
   /**


### PR DESCRIPTION
This PR adds an implementation of the [/publisher/export/run](https://docs.piano.io/api/?endpoint=get~2F~2Fpublisher~2Fexport~2Frun) endpoint.

I tested the implementation a couple times using the IDs of failed exports. Each time I confirmed that processing of the export had started again using the Piano Client Dashboard, as well as with the existing [/publisher/export/get](https://github.com/kodansha/piano-sdk-for-nodejs/blob/master/src/lib/publisher/export/index.ts#L28) implementation.