### PR TITLE
Add sync payment method to gmo api

### DIFF
--- a/src/lib/interfaces/api-params.ts
+++ b/src/lib/interfaces/api-params.ts
@@ -249,3 +249,9 @@ export interface PublisherTermChangeGetSubscriptionUpgradeStatusParams {
 export interface PublisherTermChangeCancelParams {
   subscription_from: string;
 }
+
+export interface PublisherPaymentMethodGmoRefreshParams {
+  uid: string;
+  upi_ext_payment_id: string;
+  upi_ext_customer_id: string;
+}

--- a/src/lib/interfaces/api-response.ts
+++ b/src/lib/interfaces/api-response.ts
@@ -100,3 +100,7 @@ export interface PublisherTermChangeCancelResponse
   extends ApiResponse {
     data: boolean;
   }
+
+export interface PublisherPaymentMethodGmoRefreshResponse extends ApiResponse {
+  data: boolean;
+}

--- a/src/lib/publisher/index.ts
+++ b/src/lib/publisher/index.ts
@@ -4,6 +4,7 @@ import { Export } from './export';
 import { Subscription } from './subscription';
 import { Term } from './term';
 import { User } from './user';
+import { Payment } from './payment';
 
 export class Publisher {
   public readonly user: User;
@@ -11,6 +12,7 @@ export class Publisher {
   public readonly conversion: Conversion;
   public readonly export: Export;
   public readonly term: Term;
+  public readonly payment: Payment;
 
   constructor(piano: Piano) {
     this.user = new User(piano);
@@ -18,5 +20,6 @@ export class Publisher {
     this.conversion = new Conversion(piano);
     this.export = new Export(piano);
     this.term = new Term(piano);
+    this.payment = new Payment(piano);
   }
 }

--- a/src/lib/publisher/payment/index.ts
+++ b/src/lib/publisher/payment/index.ts
@@ -1,0 +1,9 @@
+import { Piano } from '../../piano';
+import { Method } from './method';
+
+export class Payment {
+  public readonly method: Method;
+  constructor(private readonly piano: Piano) {
+    this.method = new Method(piano);
+  }
+}

--- a/src/lib/publisher/payment/method/gmo/index.ts
+++ b/src/lib/publisher/payment/method/gmo/index.ts
@@ -1,0 +1,28 @@
+import { PublisherPaymentMethodGmoRefreshParams } from '../../../../interfaces/api-params';
+import { PublisherPaymentMethodGmoRefreshResponse } from '../../../../interfaces/api-response';
+import { Piano } from '../../../../piano';
+import { httpRequest } from '../../../../utils/http-request';
+
+const ENDPOINT_PATH_PREFIX = '/publisher/payment/method/gmo';
+
+export class Gmo {
+  constructor(private readonly piano: Piano) {}
+
+  /**
+   * Sync payment method to GMO
+   *
+   * @see https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fpayment~2Fmethod~2Fgmo~2Frefresh
+   */
+  public async refresh(
+    params: PublisherPaymentMethodGmoRefreshParams
+  ): Promise<boolean> {
+    const apiResponse = (await httpRequest(
+      'post',
+      `${ENDPOINT_PATH_PREFIX}/refresh`,
+      this.piano.mergeParams(params),
+      this.piano.environment
+    )) as PublisherPaymentMethodGmoRefreshResponse;
+
+    return apiResponse.data;
+  }
+}

--- a/src/lib/publisher/payment/method/index.ts
+++ b/src/lib/publisher/payment/method/index.ts
@@ -1,0 +1,9 @@
+import { Piano } from '../../../piano';
+import { Gmo } from './gmo';
+
+export class Method {
+  public readonly gmo: Gmo;
+  constructor(private readonly piano: Piano) {
+    this.gmo = new Gmo(piano);
+  }
+}


### PR DESCRIPTION
This pull request adds the [/publisher/payment/method/gmo/refresh](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fpayment~2Fmethod~2Fgmo~2Frefresh) endpoint.

When I tested this API after registering credit card with GMO, I was able to confirm that the card information was synced to Piano.