### PR TITLE
Add support for eu environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Also, you must pick an API environment from the followings (See ["Environments" 
 - `us`
 - `au` - Australia
 - `ap` - Asia-Pacific
+- `eu` - Europe
 - `sandbox` - Sandbox
 
 The following example demonstrates fetching a user data which has uid: `abcdefg`:

--- a/src/lib/interfaces/client.ts
+++ b/src/lib/interfaces/client.ts
@@ -1,1 +1,1 @@
-export type Environment = "us" | "au" | "ap" | "sandbox";
+export type Environment = "us" | "au" | "ap" | "eu" | "sandbox";

--- a/src/lib/utils/http-request.ts
+++ b/src/lib/utils/http-request.ts
@@ -7,6 +7,7 @@ import { ApiResponse } from '../interfaces/api-response';
 const usBaseUrl = 'https://api.piano.io/api/v3';
 const auBaseUrl = 'https://api-au.piano.io/api/v3';
 const apBaseUrl = 'https://api-ap.piano.io/api/v3';
+const euBaseUrl = 'https://api-eu.piano.io/api/v3';
 const sandboxBaseUrl = 'https://sandbox.piano.io/api/v3';
 
 /**
@@ -33,6 +34,8 @@ export const httpRequest = async (
       ? auBaseUrl
       : environment == 'ap'
       ? apBaseUrl
+      : environment == 'eu'
+      ? euBaseUrl
       : sandboxBaseUrl;
 
   const endpoint = `${baseUrl}${path}`;


### PR DESCRIPTION
This PR adds support for the `eu` region (`https://api-eu.piano.io/api/v3`) described in https://docs.piano.io/api/.

I don't have access to API credentials for `eu` but I verified that I got the expected error messages when making API calls for that region.