### PR TITLE
Update user properties

### DIFF
--- a/src/lib/interfaces/user.ts
+++ b/src/lib/interfaces/user.ts
@@ -1,11 +1,11 @@
 export interface User {
-  first_name: string;
-  last_name: string;
+  first_name: string | null;
+  last_name: string | null;
   email: string;
   personal_name?: string | null;
   uid: string;
-  image1: string;
-  create_date: any;
+  image1: string | null;
+  create_date: number;
   reset_password_email_sent?: boolean;
   custom_fields?: any;
 }

--- a/src/lib/interfaces/user.ts
+++ b/src/lib/interfaces/user.ts
@@ -6,6 +6,7 @@ export interface User {
   uid: string;
   image1: string | null;
   create_date: number;
+  display_name: string;
   reset_password_email_sent?: boolean;
   custom_fields?: any;
 }


### PR DESCRIPTION
This PR makes the following updates to the `User` interface:
- add `display_name`
- update the types of a number of properties to reflect that they can be null
- change the type of `create_date` to `number`

I noticed these discrepancies with the type definitions in the responses from the `/publisher/user/email/get` and `/publisher/user/emai/list` APIs while reviewing https://github.com/kodansha/piano-sdk-for-nodejs/pull/36

I also checked the types of relevant properties in the responses to the following APIs and made sure they were consistent with the updated types:
- `/publisher/subscription/list`
- `/publisher/user/list`
- `/publisher/user/get`
- `/publisher/conversion/list`

(Interestingly, for `/publisher/user/list`, if a user doesn't have values for `first_name` or `last_name` the values returned are the empty string `''`, whereas in the other APIs we get null, but this is still consistent with the updated type definitions)