### PR TITLE
Update date type in SubscriptionUpgradeStatus

### DIFF
--- a/src/lib/interfaces/subscription-upgrade-status.ts
+++ b/src/lib/interfaces/subscription-upgrade-status.ts
@@ -10,9 +10,9 @@ export interface SubscriptionUpgradeStatus {
   to_term_name: string;
   from_term_id: string;
   to_term_id: string;
-  change_date: string;
-  create_date_from: string;
-  create_date_to: string;
+  change_date: string | null;
+  create_date_from: string | null;
+  create_date_to: string | null;
   billing_plan_to: string;
   billing_plan_from: string;
   status: SubscriptionUpgradeStatusFlag;

--- a/src/lib/interfaces/subscription-upgrade-status.ts
+++ b/src/lib/interfaces/subscription-upgrade-status.ts
@@ -6,17 +6,17 @@ export enum SubscriptionUpgradeStatusFlag {
 }
 
 export interface SubscriptionUpgradeStatus {
-  from_term_name: string;
-  to_term_name: string;
-  from_term_id: string;
-  to_term_id: string;
+  from_term_name: string | null;
+  to_term_name: string | null;
+  from_term_id: string | null;
+  to_term_id: string | null;
   change_date: string | null;
   create_date_from: string | null;
   create_date_to: string | null;
-  billing_plan_to: string;
-  billing_plan_from: string;
+  billing_plan_to: string | null;
+  billing_plan_from: string | null;
   status: SubscriptionUpgradeStatusFlag;
   error_message: string;
-  prorate_amount: string;
-  prorate_refund_amount: string;
+  prorate_amount: string | null;
+  prorate_refund_amount: string | null;
 }


### PR DESCRIPTION
This updates the [/publisher/term/change/getSubscriptionUpgradeStatus](https://docs.piano.io/api?endpoint=post~2F~2Fpublisher~2Fterm~2Fchange~2FgetSubscriptionUpgradeStatus) endpoint to change some date parameters type. 

The date fields contained in SubscriptionUpgradeStatus could return null, so I've changed it to allow null values.


Actual sample response for `/publisher/term/change/getSubscriptionUpgradeStatus`

<details><summary>Sample 1</summary>

```json
{
  "code": 0,
  "ts": 1741603384,
  "subscription_upgrade_status": {
    "from_term_name": "XXXX",
    "to_term_name": "YYYY",
    "change_date": "Sep 24, 2022",
    "create_date_from": "Aug 24, 2022",
    "create_date_to": null,
    "billing_plan_to": "JPY1,200 per month",
    "billing_plan_from": "JPY700 per month",
    "to_term_id": "XXXX",
    "from_term_id": "YYYY",
    "status": 0,
    "prorate_amount": null,
    "prorate_refund_amount": null
  }
}
```

</details> 

<details><summary>Sample 2</summary>

```json
{
  "code": 0,
  "ts": 1745806903,
  "subscription_upgrade_status": {
    "from_term_name": null,
    "to_term_name": "YYYY",
    "change_date": null,
    "create_date_from": null,
    "create_date_to": "Jan 25, 2023",
    "billing_plan_to": "JPY50,000 per month",
    "billing_plan_from": null,
    "to_term_id": "XXXX",
    "from_term_id": null,
    "status": -1,
    "prorate_amount": null,
    "prorate_refund_amount": null
  }
}
```

</details> 
